### PR TITLE
Make travis build badge clickable.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# LibChaos ![Travis-CI Badge](https://api.travis-ci.org/ChaoticConundrum/libchaos.svg?branch=master "Travis-CI Badge")
+# LibChaos [![Travis-CI Badge](https://api.travis-ci.org/ChaoticConundrum/libchaos.svg?branch=master "Travis-CI Badge")](https://travis-ci.org/ChaoticConundrum/libchaos)
 
 LibChaos is a general-purpose C++ utilities library.
 


### PR DESCRIPTION
This is convenient when the build is borked.