### PR TITLE
[patches/pok3r] zerror: fix build due to SIGSTKSZ no longer being statically-defined

### DIFF
--- a/chaos/base/zerror.cpp
+++ b/chaos/base/zerror.cpp
@@ -797,7 +797,7 @@ bool registerSignalHandler(zerror_signal sigtype, signalHandler handler){
 
     sigmap[sig] = { sigtype, handler };
 
-    static uint8_t alternate_stack[SIGSTKSZ];
+    uint8_t alternate_stack[SIGSTKSZ];
     stack_t ss;
      /* malloc is usually used here, I'm not 100% sure my static allocation
      is valid but it seems to work just fine. */


### PR DESCRIPTION
SIGSTKSZ is now a run-time variable and this PR removes static keyword from affected variable to fix compilation on Linux.

Reference: https://lists.gnu.org/archive/html/bug-m4/2021-03/msg00000.html

Error from pok3rtool build without commit:
```
/home/hansemro/Documents/pok3rtool/libchaos/chaos/base/zerror.cpp:800:20: warning: ISO C++ forbids variable length array ‘alternate_stack’ [-Wvla]
  800 |     static uint8_t alternate_stack[SIGSTKSZ];
      |                    ^~~~~~~~~~~~~~~
/home/hansemro/Documents/pok3rtool/libchaos/chaos/base/zerror.cpp:800:20: error: storage size of ‘alternate_stack’ isn’t constant
```